### PR TITLE
Add flake8 config and format dashboard module

### DIFF
--- a/danish_energy_project/.flake8
+++ b/danish_energy_project/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, W503


### PR DESCRIPTION
## Summary
- add a project `.flake8` config with a longer line length
- clean up `dashboards/dashboard_api.py` to satisfy new style rules
- show flake8 errors for the rest of the project

## Testing
- `flake8 dashboards/dashboard_api.py`
- `flake8 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_686fedbf8e30832cbff49e719832848e