### PR TITLE
Add stop_services utility script

### DIFF
--- a/danish_energy_project/README.md
+++ b/danish_energy_project/README.md
@@ -16,6 +16,8 @@ cd danish_energy_project
 
 # Start services
 ./start_services.sh
+# Stop services
+./stop_services.sh
 ```
 
 ### Option 3: Manual Setup

--- a/danish_energy_project/start_services.sh
+++ b/danish_energy_project/start_services.sh
@@ -7,6 +7,7 @@ set -e
 
 echo "🚀 Starting Danish Energy Analytics Platform Services"
 echo "=================================================="
+echo "Use ./stop_services.sh to stop the services"
 
 # Check if we're in the right directory
 if [ ! -f "data_ingestion/extract_energy_data.py" ]; then
@@ -128,7 +129,7 @@ show_status() {
     echo "  API Docs:       http://localhost:5000/docs"
     echo "  Tech Docs:      docs/technical_docs/"
     echo ""
-    echo "Press Ctrl+C to stop all services"
+    echo "Press Ctrl+C or run ./stop_services.sh to stop all services"
 }
 
 # Function to cleanup on exit

--- a/danish_energy_project/stop_services.sh
+++ b/danish_energy_project/stop_services.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Danish Energy Analytics Platform - Stop Services Script
+# Stops running platform services using stored PID files
+
+set -e
+
+echo "🛑 Stopping Danish Energy Analytics Platform services"
+
+# Ensure we're in the project root
+if [ ! -f "data_ingestion/extract_energy_data.py" ]; then
+    echo "❌ Please run this script from the danish_energy_project directory"
+    exit 1
+fi
+
+stop_service() {
+    local pid_file="$1"
+    local name="$2"
+
+    if [ -f "$pid_file" ]; then
+        local pid=$(cat "$pid_file")
+        kill "$pid" 2>/dev/null || true
+        rm "$pid_file"
+        echo "✅ $name stopped"
+    else
+        echo "ℹ️ $name not running"
+    fi
+}
+
+stop_service api.pid "API server"
+stop_service dashboard.pid "Dashboard"
+stop_service ml.pid "ML server"
+
+echo "🚦 All services stopped"


### PR DESCRIPTION
## Summary
- add script to stop background services using PID files
- guide users to use stop_services.sh from start_services.sh
- document start & stop usage in README

## Testing
- `bash -n danish_energy_project/start_services.sh`
- `bash -n danish_energy_project/stop_services.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fedafc5b8832c8b7f1c735a12393b