### PR TITLE
Add configurable data path

### DIFF
--- a/danish_energy_project/README.md
+++ b/danish_energy_project/README.md
@@ -12,6 +12,10 @@ Visit the live dashboard: **https://vrqaqogw.manus.space**
 # Extract and setup
 tar -xzf danish_energy_analytics_platform.tar.gz
 cd danish_energy_project
+
+# Optional: specify where raw CSVs are stored
+export DANISH_ENERGY_DATA_PATH=/path/to/raw_data
+
 ./quick_setup.sh
 
 # Start services

--- a/danish_energy_project/ml_models/danish_energy_ml_pipeline.py
+++ b/danish_energy_project/ml_models/danish_energy_ml_pipeline.py
@@ -3,6 +3,8 @@ Danish Energy ML Pipeline
 Comprehensive machine learning models for Danish energy analytics
 """
 
+import os
+import argparse
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -28,7 +30,22 @@ class DanishEnergyMLPipeline:
     Comprehensive ML pipeline for Danish energy analytics
     """
     
-    def __init__(self, data_path='/home/ubuntu/danish_energy_project/data_ingestion/raw_data'):
+    def __init__(self, data_path=None):
+        """Initialize the ML pipeline.
+
+        Args:
+            data_path: Optional path to the folder containing raw CSV files. If
+                not provided, the value is read from the ``DANISH_ENERGY_DATA_PATH``
+                environment variable or defaults to
+                ``/home/ubuntu/danish_energy_project/data_ingestion/raw_data``.
+        """
+
+        if data_path is None:
+            data_path = os.getenv(
+                "DANISH_ENERGY_DATA_PATH",
+                "/home/ubuntu/danish_energy_project/data_ingestion/raw_data",
+            )
+
         self.data_path = data_path
         self.models = {}
         self.scalers = {}
@@ -791,10 +808,22 @@ class DanishEnergyMLPipeline:
 
 def main():
     """Main execution function"""
+
+    parser = argparse.ArgumentParser(description="Run the Danish Energy ML pipeline")
+    parser.add_argument(
+        "--data-path",
+        default=os.getenv(
+            "DANISH_ENERGY_DATA_PATH",
+            "/home/ubuntu/danish_energy_project/data_ingestion/raw_data",
+        ),
+        help="Path to folder containing raw CSV files",
+    )
+    args = parser.parse_args()
+
     print("Starting Danish Energy ML Pipeline...")
-    
+
     # Initialize pipeline
-    pipeline = DanishEnergyMLPipeline()
+    pipeline = DanishEnergyMLPipeline(data_path=args.data_path)
     
     # Load and prepare data
     data = pipeline.load_and_prepare_data()

--- a/danish_energy_project/quick_setup.sh
+++ b/danish_energy_project/quick_setup.sh
@@ -5,6 +5,11 @@
 
 set -e  # Exit on any error
 
+# Default location for raw CSVs
+DATA_PATH_DEFAULT="$(pwd)/data_ingestion/raw_data"
+export DANISH_ENERGY_DATA_PATH="${DANISH_ENERGY_DATA_PATH:-$DATA_PATH_DEFAULT}"
+echo "Using data path: $DANISH_ENERGY_DATA_PATH"
+
 echo "🚀 Danish Energy Analytics Platform - Quick Setup"
 echo "================================================="
 


### PR DESCRIPTION
## Summary
- allow overriding dataset path in `danish_energy_ml_pipeline.py` via env var or CLI argument
- export `DANISH_ENERGY_DATA_PATH` in `quick_setup.sh`
- document dataset path configuration in the main README

## Testing
- `flake8 ml_models/danish_energy_ml_pipeline.py` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_686fedadfddc832c851d35202438d26a