### PR TITLE
Update README metrics and remove dashboard link

### DIFF
--- a/danish_energy_project/README.md
+++ b/danish_energy_project/README.md
@@ -4,10 +4,8 @@ A comprehensive end-to-end data engineering and analytics platform for Danish en
 
 ## 🚀 Quick Start
 
-### Option 1: Use Live Dashboard (Immediate)
-Visit the live dashboard: **https://vrqaqogw.manus.space**
 
-### Option 2: Local Setup (5 minutes)
+### Option 1: Local Setup (5 minutes)
 ```bash
 # Extract and setup
 tar -xzf danish_energy_analytics_platform.tar.gz
@@ -18,12 +16,12 @@ cd danish_energy_project
 ./start_services.sh
 ```
 
-### Option 3: Manual Setup
+### Option 2: Manual Setup
 See detailed instructions in `docs/deployment_guides/deployment_guide.md`
 
 ## 📊 What's Included
 
-- **Real-time Data Processing**: 1.4M+ records from Danish energy sources
+- **Real-time Data Processing**: ~1.4M records from Danish energy sources
 - **Machine Learning Models**: 97% accuracy for price prediction
 - **Interactive Dashboard**: React-based with real-time updates
 - **Data Warehouse**: PostgreSQL with star schema design
@@ -56,9 +54,7 @@ See detailed instructions in `docs/deployment_guides/deployment_guide.md`
 
 ## 📈 Performance
 
-- **Data Processing**: 50,000+ records/minute
-- **Query Response**: <1 second for complex analytics
-- **Dashboard Load**: <2 seconds
+- **Data Volume**: ~1.4M records across 2020-2024 (see `data_ingestion/raw_data/`)
 - **Model Accuracy**: 97% for electricity prices, 91% for renewable energy
 
 ## 🔧 Project Structure
@@ -83,10 +79,9 @@ danish_energy_project/
 
 ## 🚀 Getting Started
 
-1. **Explore the Live Dashboard**: https://vrqaqogw.manus.space
-2. **Read the User Guide**: `docs/user_guides/user_guide.md`
-3. **Setup Locally**: Run `./quick_setup.sh` for automated installation
-4. **Deploy to Production**: Follow `docs/deployment_guides/deployment_guide.md`
+1. **Read the User Guide**: `docs/user_guides/user_guide.md`
+2. **Setup Locally**: Run `./quick_setup.sh` for automated installation
+3. **Deploy to Production**: Follow `docs/deployment_guides/deployment_guide.md`
 
 ## 📞 Support
 
@@ -97,15 +92,13 @@ danish_energy_project/
 
 ## 🎉 Success Metrics
 
-- **1,205+ files** created with complete source code
-- **309 MB** comprehensive project package
-- **99.9% uptime** target with robust error handling
+- **168 files** in this repository
+- **109 MB** total project size (29 MB compressed)
 - **Enterprise-ready** with production deployment guides
 
 ---
 
-**Live Dashboard**: https://vrqaqogw.manus.space  
-**Project Size**: 309 MB (51 MB compressed)  
+**Project Size**: 109 MB (29 MB compressed)  
 **Development Time**: 8 comprehensive phases  
 **Status**: Production Ready ✅
 


### PR DESCRIPTION
## Summary
- update reported project size and file count in `danish_energy_project/README.md`
- remove references to inaccessible live dashboard
- clarify data volume and model accuracy metrics
- clean up quick start and getting started instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686feda80298832c8efe18b3869d810b