### PR TITLE
Enable long range dashboard views

### DIFF
--- a/DELIVERY_README.md
+++ b/DELIVERY_README.md
@@ -82,10 +82,15 @@ danish_energy_project/
 ### **Option 1: Use Live Dashboard (Immediate)**
 1. Visit: https://vrqaqogw.manus.space
 2. Explore the 4 analysis tabs (Renewable Energy, CO₂ Emissions, Electricity Prices, Daily Patterns)
-3. Use time controls (7, 30, 90 days) to analyze different periods
+3. Use time controls (7 days up to 5 years) to analyze different periods
 4. Hover over charts for detailed insights
 
-### **Option 2: Local Development Setup**
+### **Option 2: Local Development Setup (Automated)**
+```bash
+make up
+```
+
+If you prefer manual steps:
 ```bash
 # 1. Extract the project
 tar -xzf danish_energy_analytics_platform.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: setup start stop up test
+
+setup:
+	bash danish_energy_project/quick_setup.sh
+
+start:
+	bash danish_energy_project/start_services.sh
+
+stop:
+	bash danish_energy_project/stop_services.sh
+
+up: setup start
+
+test:
+	pip install -q pytest pandas psycopg2-binary flask flask-cors
+	pytest -q

--- a/danish_energy_project/README.md
+++ b/danish_energy_project/README.md
@@ -4,6 +4,15 @@ A comprehensive end-to-end data engineering and analytics platform for Danish en
 
 ## 🚀 Quick Start
 
+### Option 0: Makefile Quick Setup (1 command)
+```bash
+make up
+# Stop services
+make stop
+# Run tests
+make test
+```
+
 
 ### Option 1: Local Setup (5 minutes)
 ```bash

--- a/danish_energy_project/dashboards/README.md
+++ b/danish_energy_project/dashboards/README.md
@@ -68,8 +68,9 @@
 
 ### 📈 **Business Intelligence Features**
 
-#### **Time Range Controls**
-- **7, 30, 90-day views** with dynamic data filtering
+-#### **Time Range Controls**
+- **7-day to 5-year views** with dynamic data filtering
+- **Extended ranges**: 6 months, 1 year, and 5 years (monthly)
 - **Real-time refresh** capability for live monitoring
 - **Last updated timestamp** for data freshness tracking
 

--- a/danish_energy_project/dashboards/energy-dashboard/src/App.jsx
+++ b/danish_energy_project/dashboards/energy-dashboard/src/App.jsx
@@ -29,13 +29,14 @@ function App() {
   const fetchData = async () => {
     setLoading(true)
     try {
+      const aggregate = selectedDays >= 365 ? 'month' : 'day'
       const [kpisRes, renewableRes, co2Res, priceRes, hourlyRes, mixRes] = await Promise.all([
-        fetch(`${API_BASE_URL}/kpis`),
-        fetch(`${API_BASE_URL}/renewable-trends?days=${selectedDays}`),
-        fetch(`${API_BASE_URL}/co2-analysis?days=${selectedDays}`),
-        fetch(`${API_BASE_URL}/price-analysis?days=${selectedDays}`),
+        fetch(`${API_BASE_URL}/kpis?days=${selectedDays}`),
+        fetch(`${API_BASE_URL}/renewable-trends?days=${selectedDays}&aggregate=${aggregate}`),
+        fetch(`${API_BASE_URL}/co2-analysis?days=${selectedDays}&aggregate=${aggregate}`),
+        fetch(`${API_BASE_URL}/price-analysis?days=${selectedDays}&aggregate=${aggregate}`),
         fetch(`${API_BASE_URL}/hourly-patterns`),
-        fetch(`${API_BASE_URL}/energy-mix?days=${selectedDays}`)
+        fetch(`${API_BASE_URL}/energy-mix?days=${selectedDays}&aggregate=${aggregate}`)
       ])
 
       const [kpisData, renewableData, co2Data, priceData, hourlyData, mixData] = await Promise.all([
@@ -167,13 +168,37 @@ function App() {
               >
                 30 Days
               </Button>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 size="sm"
                 onClick={() => setSelectedDays(90)}
                 className={selectedDays === 90 ? 'bg-primary text-primary-foreground' : ''}
               >
                 90 Days
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSelectedDays(180)}
+                className={selectedDays === 180 ? 'bg-primary text-primary-foreground' : ''}
+              >
+                6 Months
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSelectedDays(365)}
+                className={selectedDays === 365 ? 'bg-primary text-primary-foreground' : ''}
+              >
+                1 Year
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSelectedDays(1825)}
+                className={selectedDays === 1825 ? 'bg-primary text-primary-foreground' : ''}
+              >
+                5 Years
               </Button>
               <Button onClick={fetchData} size="sm">
                 Refresh

--- a/danish_energy_project/dashboards/mock_dashboard_api.py
+++ b/danish_energy_project/dashboards/mock_dashboard_api.py
@@ -131,17 +131,29 @@ def get_kpis():
 
 @app.route('/api/renewable-trends')
 def get_renewable_trends():
-    days = request.args.get('days', 30, type=int)
+    days = request.args.get('days', type=int)
+    months = request.args.get('months', type=int)
+    if days is None and months is not None:
+        days = months * 30
+    days = days or 30
     return jsonify(generate_mock_renewable_trends(days))
 
 @app.route('/api/co2-analysis')
 def get_co2_analysis():
-    days = request.args.get('days', 30, type=int)
+    days = request.args.get('days', type=int)
+    months = request.args.get('months', type=int)
+    if days is None and months is not None:
+        days = months * 30
+    days = days or 30
     return jsonify(generate_mock_co2_analysis(days))
 
 @app.route('/api/price-analysis')
 def get_price_analysis():
-    days = request.args.get('days', 30, type=int)
+    days = request.args.get('days', type=int)
+    months = request.args.get('months', type=int)
+    if days is None and months is not None:
+        days = months * 30
+    days = days or 30
     return jsonify(generate_mock_price_analysis(days))
 
 @app.route('/api/hourly-patterns')
@@ -150,7 +162,11 @@ def get_hourly_patterns():
 
 @app.route('/api/energy-mix')
 def get_energy_mix():
-    days = request.args.get('days', 30, type=int)
+    days = request.args.get('days', type=int)
+    months = request.args.get('months', type=int)
+    if days is None and months is not None:
+        days = months * 30
+    days = days or 30
     return jsonify(generate_mock_energy_mix(days))
 
 @app.route('/api/health')

--- a/danish_energy_project/dashboards/power_bi/README.md
+++ b/danish_energy_project/dashboards/power_bi/README.md
@@ -78,7 +78,7 @@ SWITCH(
 ## Dashboard Features
 
 ### Interactive Elements
-- **Date Range Selector**: 7, 30, 90 days, or custom range
+- **Date Range Selector**: 7, 30, 90 days, extended to 6 months, 1 year, or 5 years
 - **Regional Filter**: DK1, DK2, or combined view
 - **Energy Source Filter**: Wind, Solar, Hydro, Conventional
 - **Time Period Filter**: Peak hours, off-peak, weekends

--- a/danish_energy_project/docs/user_guides/user_guide.md
+++ b/danish_energy_project/docs/user_guides/user_guide.md
@@ -45,7 +45,7 @@ The platform uses a tab-based navigation system with the following key elements:
 
 - **Header**: Displays the platform title and current data timestamp
 - **Navigation Tabs**: Switch between different analysis views
-- **Time Controls**: Adjust the analysis period (7, 30, or 90 days)
+- **Time Controls**: Adjust the analysis period (7 days up to 5 years)
 - **KPI Cards**: Show key metrics at the top of each tab
 - **Interactive Charts**: Provide detailed visualizations with hover tooltips
 - **Data Tables**: Display underlying data in tabular format

--- a/tests/test_dashboard_data_service.py
+++ b/tests/test_dashboard_data_service.py
@@ -13,10 +13,10 @@ def test_get_renewable_trends_calls_execute_query():
     service = DashboardDataService({'host': 'h', 'database': 'd', 'user': 'u', 'password': 'p'})
     df = pd.DataFrame({'a': [1]})
     with patch.object(service, 'execute_query', return_value=df) as mock_exec:
-        result = service.get_renewable_trends(days=7)
+        result = service.get_renewable_trends(days=7, aggregate='day')
         mock_exec.assert_called_once()
         args, _ = mock_exec.call_args
-        assert args[1] == (7,)
+        assert args[1] == ('7 days',)
         assert result.equals(df)
 
 


### PR DESCRIPTION
## Summary
- extend available date ranges to support up to 5 years of monthly data
- add month aggregation logic in dashboard API
- update React dashboard to call new query parameters and show more buttons
- adjust mock API and docs
- update tests
- provide Makefile for one-command setup

## Testing
- `pip install -q pytest pandas psycopg2-binary flask flask-cors`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fefb9ffd0832ca584d05aa82019b2